### PR TITLE
Fix extra semicolons in stepper driver

### DIFF
--- a/AVR-EB-Stepper-fw.X/stepper.c
+++ b/AVR-EB-Stepper-fw.X/stepper.c
@@ -171,7 +171,7 @@ static void StepAdvance(bool direction)
         case 0x00:  a = 0;
                     b = sine_lookup_table[31 - (step & 0x1F)];
                     c = 0;
-                    d = sine_lookup_table[step & 0x1F];;
+                    d = sine_lookup_table[step & 0x1F];
                     break;
         case 0x20: 
                     a = sine_lookup_table[step & 0x1F];
@@ -182,7 +182,7 @@ static void StepAdvance(bool direction)
         case 0x40:            
                     a = sine_lookup_table[31 - (step & 0x1F)];
                     b = 0;
-                    c = sine_lookup_table[step & 0x1F];;
+                    c = sine_lookup_table[step & 0x1F];
                     d = 0;
                     break;     
         case 0x60: 

--- a/AVR-EB-Stepper-fw2.X/stepper.c
+++ b/AVR-EB-Stepper-fw2.X/stepper.c
@@ -171,7 +171,7 @@ static void StepAdvance(bool direction)
         case 0x00:  a = 0;
                     b = sine_lookup_table[31 - (step & 0x1F)];
                     c = 0;
-                    d = sine_lookup_table[step & 0x1F];;
+                    d = sine_lookup_table[step & 0x1F];
                     break;
         case 0x20: 
                     a = sine_lookup_table[step & 0x1F];
@@ -182,7 +182,7 @@ static void StepAdvance(bool direction)
         case 0x40:            
                     a = sine_lookup_table[31 - (step & 0x1F)];
                     b = 0;
-                    c = sine_lookup_table[step & 0x1F];;
+                    c = sine_lookup_table[step & 0x1F];
                     d = 0;
                     break;     
         case 0x60: 


### PR DESCRIPTION
## Summary
- remove stray semicolons in stepper advance state machine

## Testing
- `make -C AVR-EB-Stepper-fw.X` *(fails: nbproject/Makefile-variables.mk missing)*
- `make -C AVR-EB-Stepper-fw2.X` *(fails: nbproject/Makefile-variables.mk missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f4264acd08323b49cf8284bd5eb44