### PR TITLE
Enable 32‑bit speed control

### DIFF
--- a/AVR-EB-Stepper-fw2.X/main.c
+++ b/AVR-EB-Stepper-fw2.X/main.c
@@ -48,17 +48,17 @@ uint16_t Get_VBus(adc_0_channel_t channel)
     return vbus_mv;
 }
 
-stepper_position_t MainMove(stepper_position_t position, stepper_position_t displacement, uint16_t speed)
+stepper_position_t MainMove(stepper_position_t position, stepper_position_t displacement, uint32_t speed)
 {
     /* Acceleration and deceleration to ramp 0-400RPM in about 5 seconds */
-    uint16_t acc   = DEGPS_TO_U16(0.024);
-    uint16_t decc  = DEGPS_TO_U16(0.024);
+    uint32_t acc   = DEGPS_TO_U32(0.024);
+    uint32_t decc  = DEGPS_TO_U32(0.024);
     uint16_t vbus;
 
     vbus = Get_VBus(VBUS_ADC);
     printf("\n\rSupply voltage: \t%.2f V", 0.001*(float)vbus);
     printf("\n\rInitial position:\t%.2f steps / %ld sub-steps", SUBSTEPS_TO_STEPS(position), position);
-    printf("\n\rMoving with speed:\t%.3f degrees/second", U16_TO_DEGPS(speed));
+    printf("\n\rMoving with speed:\t%.3f degrees/second", U32_TO_DEGPS(speed));
     position = Stepper_Move(position, displacement, acc, decc, speed, vbus);
     printf("\n\rFinal position: \t%.2f steps / %ld sub-steps", SUBSTEPS_TO_STEPS(position), position);
     printf("\n\r");
@@ -85,7 +85,7 @@ int main(void)
     while(1)
     {
         stepper_position_t sub_steps = STEPS_TO_SUBSTEPS(6667);
-        uint16_t speed = SPEED_LIMIT(DEGPS_TO_U16(400 * 6.0));
+        uint32_t speed = SPEED_LIMIT(DEGPS_TO_U32(400 * 6.0));
 
         stepper_position = MainMove(stepper_position, sub_steps, speed);
         _delay_ms(500);

--- a/AVR-EB-Stepper-fw2.X/stepper.c
+++ b/AVR-EB-Stepper-fw2.X/stepper.c
@@ -57,10 +57,10 @@ typedef enum
 #define RESET_CMD   true
 
 /* This function returns true if the delay for the next step expired */
-static inline bool CheckSteps(bool reset_cmd, uint16_t actual_speed)
+static inline bool CheckSteps(bool reset_cmd, uint32_t actual_speed)
 {
-    static uint16_t counter = 0;
-    uint16_t pre_counter;
+    static uint32_t counter = 0;
+    uint32_t pre_counter;
     
     if(reset_cmd == RESET_CMD)
     {
@@ -236,10 +236,10 @@ static inline void AmplitudeSet(uint16_t amplitude)
     TCE0_AmplitudeSet(amplitude);
 }
 
-stepper_position_t Stepper_Move(stepper_position_t initial_position, stepper_position_t steps, uint16_t acceleration, uint16_t deceleration, uint16_t speed_limit, uint16_t vbus_mv)
-{  
+stepper_position_t Stepper_Move(stepper_position_t initial_position, stepper_position_t steps, uint32_t acceleration, uint32_t deceleration, uint32_t speed_limit, uint16_t vbus_mv)
+{
     stepper_position_t actual_position = initial_position;
-    uint16_t actual_speed = 0;
+    uint32_t actual_speed = 0;
     bool direction;
     uint32_t steps_to_go;
     uint32_t steps_until_stop = 0;

--- a/AVR-EB-Stepper-fw2.X/stepper.h
+++ b/AVR-EB-Stepper-fw2.X/stepper.h
@@ -72,14 +72,14 @@ typedef int32_t  stepper_position_t;
 
 
 /* DEGPS - degrees per second */
-/* Converts degrees per second into 16 bit integer */
-#define DEGPS_TO_U16(dps)                       (uint16_t)(((dps) * 65536.0 * TICK_INTERVAL * K_MODE) / (STEP_SIZE * 1000000.0) + 0.5)
+/* Converts degrees per second into 32 bit integer */
+#define DEGPS_TO_U32(dps)                       (uint32_t)(((dps) * 65536.0 * TICK_INTERVAL * K_MODE) / (STEP_SIZE * 1000000.0) + 0.5)
 
-/* Converts 16 bit integer into degrees per second */
-#define U16_TO_DEGPS(u16)                       (float)((STEP_SIZE * (u16) * 1000000.0) / (65536.0 * TICK_INTERVAL * K_MODE))
+/* Converts 32 bit integer into degrees per second */
+#define U32_TO_DEGPS(u32)                       (float)((STEP_SIZE * (u32) * 1000000.0) / (65536.0 * TICK_INTERVAL * K_MODE))
 
 /* Speed limit */
-#define  SPEED_LIMIT(SPEED_U16)                 (uint16_t)(((SPEED_U16) > 32768) ? (32768) : (SPEED_U16))
+#define  SPEED_LIMIT(SPEED_U32)                 (uint32_t)(SPEED_U32)
 
 /* Converts steps into substeps */
 #define STEPS_TO_SUBSTEPS(STEPS)                (stepper_position_t)((STEPS)*(float)K_MODE)
@@ -95,7 +95,7 @@ typedef int32_t  stepper_position_t;
 
   returns: new position of the stepper motor
 */
-stepper_position_t Stepper_Move(stepper_position_t, stepper_position_t, uint16_t, uint16_t, uint16_t, uint16_t);
+stepper_position_t Stepper_Move(stepper_position_t, stepper_position_t, uint32_t, uint32_t, uint32_t, uint16_t);
 void               Stepper_TimeTick(void);  /* Called periodically from interrupt context */
 void               Stepper_Init(void);
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ The Microstep mode divides the full-step angle into even smaller steps, providin
 
 Current limiting remains active regardless of the selected resolution.  The limit can be tweaked through the `I_OUT` definition in `stepper.h`.
 
+### Higher Speed Operation
+
+`AVR-EB-Stepper-fw2.X` previously stored the commanded speed as a 16-bit value, limiting the maximum step rate.  The firmware now uses 32-bit fixed-point arithmetic for speed calculations.  Update your application to use the new `DEGPS_TO_U32`, `U32_TO_DEGPS` and `SPEED_LIMIT` macros when specifying motion profiles.
+
 ## Related Documentation
 
 - [AVR&reg; EB Product Page](https://www.microchip.com/en-us/products/microcontrollers-and-microprocessors/8-bit-mcus/avr-mcus/avr-eb?utm_source=GitHub&utm_medium=TextLink&utm_campaign=MCU8_AVR-EB&utm_content=stepper-motor-reference-design-github-github&utm_bu=MCU08)


### PR DESCRIPTION
## Summary
- use 32‑bit values for speed calculations in AVR-EB-Stepper-fw2.X
- update main demo to use new macros
- document higher speed capabilities

## Testing
- `make` *(fails: nbproject/Makefile-variables.mk missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f559400748323a34890579300f0d1